### PR TITLE
Correction methode receptionner Eq3

### DIFF
--- a/CACAO2019/src/abstraction/eq3Transformateur1/Transformateur1.java
+++ b/CACAO2019/src/abstraction/eq3Transformateur1/Transformateur1.java
@@ -1,7 +1,6 @@
 package abstraction.eq3Transformateur1;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import abstraction.eq3Transformateur1.Stock;
@@ -58,7 +57,7 @@ public class Transformateur1 implements IActeur, IAcheteurContratCadre<Feve>, IV
 
 
 		// stock de feves
-		ArrayList<Feve> feves = new ArrayList<Feve>(Arrays.asList(Feve.values()));
+		ArrayList<Feve> feves = new ArrayList<Feve>();
 		feves.add(Feve.CRIOLLO_HG_EQ);
 		feves.add(Feve.FORASTERO_MG_EQ);
 		feves.add(Feve.FORASTERO_MG_NEQ);

--- a/CACAO2019/src/abstraction/eq3Transformateur1/Transformateur1.java
+++ b/CACAO2019/src/abstraction/eq3Transformateur1/Transformateur1.java
@@ -1,6 +1,7 @@
 package abstraction.eq3Transformateur1;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import abstraction.eq3Transformateur1.Stock;
@@ -57,7 +58,7 @@ public class Transformateur1 implements IActeur, IAcheteurContratCadre<Feve>, IV
 
 
 		// stock de feves
-		ArrayList<Feve> feves = new ArrayList<Feve>();
+		ArrayList<Feve> feves = new ArrayList<Feve>(Arrays.asList(Feve.values()));
 		feves.add(Feve.CRIOLLO_HG_EQ);
 		feves.add(Feve.FORASTERO_MG_EQ);
 		feves.add(Feve.FORASTERO_MG_NEQ);
@@ -307,15 +308,15 @@ public class Transformateur1 implements IActeur, IAcheteurContratCadre<Feve>, IV
 	@Override
 	public void receptionner(Feve produit, double quantite, ContratCadre<Feve> cc) {
 		// begin sacha
-		for (Feve f:this.stockFeves.getProduitsEnStock()) {
-			if (produit==null || !produit.equals(f)) {
-				throw new IllegalArgumentException("Appel de la methode receptionner de Transformateur1 avec un produit ne correspondant pas aux feves achetees par le transformateur");
-			}
+	//	for (Feve f:this.stockFeves.getProduitsEnStock()) {
+	//		if (produit==null || !produit.equals(f)) {
+	//			throw new IllegalArgumentException("Appel de la methode receptionner de Transformateur1 avec un produit ne correspondant pas aux feves achetees par le transformateur");
+	//		}
 			if (quantite<=0.0) {
 				throw new IllegalArgumentException("Appel de la methode receptionner de Transformateur1 avec une quantite egale a "+quantite);
 			}
 			this.stockFeves.setQuantiteEnStock(produit, this.stockFeves.getQuantiteEnStock(produit) + quantite);
-		}
+	//	}
 		
 	}
 //end sacha


### PR DESCRIPTION
Comme souligné dans mes remarques, la méthode receptionner de l'Eq3 est erronnée. L'erreur n'a pas été détectée par travis car elle ne survient pas tant qu'il n'y a pas d'échanges avec l'eq3. Actuellement cette erreur empèche les pull request d'autres équipes car des échanges s'établissent et font surgir l'erreur.
